### PR TITLE
Use the shared m2 directory until remote artifacts work

### DIFF
--- a/init-ci.gradle
+++ b/init-ci.gradle
@@ -1,2 +1,2 @@
-// Use a local m2 repo to ensure a clean build
-System.setProperty("maven.repo.local", System.getProperty("user.dir") + "/m2/repository")
+// TODO: Use a local m2 repo to ensure a clean build
+//System.setProperty("maven.repo.local", System.getProperty("user.dir") + "/m2/repository")


### PR DESCRIPTION
As discussed in Slack the plan is to get a full build (omero-gradle-plugins → omero-build → openmicroscopy) using a shared `.m2` directory